### PR TITLE
Removed "user-service" from deployment

### DIFF
--- a/deploy
+++ b/deploy
@@ -23,7 +23,6 @@ cd $DEPLOY_FOLDER
 git clone ${GIT_URL}/eureka-service.git
 git clone ${GIT_URL}/config-server.git
 git clone ${GIT_URL}/food-service.git
-git clone ${GIT_URL}/users-service.git
 git clone ${GIT_URL}/gateway-service.git
 git clone ${GIT_URL}/diary-service.git
 git clone ${GIT_URL}/ask-oracle-service.git


### PR DESCRIPTION
A database stroing the user credentials is no longer needed; the Okta identity service is being used instead.

Signed-off-by: crcostea <crina91@gmail.com>